### PR TITLE
Bugfix crash if @last_submitted_at is nil when viewing streak

### DIFF
--- a/models/streak_users.moon
+++ b/models/streak_users.moon
@@ -94,9 +94,8 @@ class StreakUsers extends Model
 
   get_current_streak: =>
     streak = @get_streak!
-
     ago = streak\increment_date_by_unit date(true), -1
-    if date(@last_submitted_at) > ago
+    if @last_submitted_at and date(@last_submitted_at) > ago
       @current_streak
     else
       0
@@ -182,4 +181,3 @@ class StreakUsers extends Model
         @notification_settings = StreakUserNotificationSettings\create streak_id: @streak_id, user_id: @user_id
 
     @notification_settings
-


### PR DESCRIPTION
I wasn't able to repro this on the live version so it may be caused by how I have my server set up.

1. Create new user.
1. Create new streak, setting date to earlier than today so that it is live.
1. Server will crash because `@last_submitted_at` is passed into the `date` function while it's value is `nil`. 

This `nil` check fixes the issue on my local server.