### PR TITLE
Add cloud storage as a dependency

### DIFF
--- a/BoxFile
+++ b/BoxFile
@@ -10,5 +10,6 @@ https://raw.githubusercontent.com/leafo/web_sanitize/master/web_sanitize-dev-1.r
 https://raw.githubusercontent.com/leafo/magick/master/magick-dev-1.rockspec
 https://raw.githubusercontent.com/leafo/lapis-systemd/master/lapis-systemd-dev-1.rockspec
 https://raw.githubusercontent.com/leafo/lapis-console/master/lapis-console-dev-1.rockspec
+https://raw.githubusercontent.com/leafo/cloud_storage/master/cloud_storage-dev-1.rockspec
 https://luarocks.org/manifests/leafo/tableshape-dev-1.rockspec
 https://luarocks.org/manifests/leafo/lapis-community-dev-1.rockspec


### PR DESCRIPTION
The server requires and will crash without `cloud_storage` installed.